### PR TITLE
docs: redesign README with dinero.js-style layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,50 @@
-# ts-hooks-kit
+<p align="center">
+  <strong>ts-hooks-kit</strong>
+</p>
 
-An actively maintained React hooks library based on usehooks-ts, upgraded for React 18/19 compatibility.
+<p align="center">
+  <a href="https://www.npmjs.com/package/@ts-hooks-kit/core"><img alt="npm version" src="https://img.shields.io/npm/v/@ts-hooks-kit/core" /></a>
+  <a href="https://www.npmjs.com/package/@ts-hooks-kit/core"><img alt="npm monthly downloads" src="https://img.shields.io/npm/dm/@ts-hooks-kit/core" /></a>
+  <a href="https://bundlephobia.com/package/@ts-hooks-kit/core"><img alt="bundle size" src="https://img.shields.io/bundlephobia/minzip/@ts-hooks-kit/core" /></a>
+  <a href="https://github.com/naufaldi/ts-hooks-kit/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/naufaldi/ts-hooks-kit" /></a><br />
+  <a href="https://www.typescriptlang.org/"><img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-Ready-blue" /></a>
+  <a href="https://github.com/naufaldi/ts-hooks-kit/actions/workflows/ci.yml"><img alt="GitHub Actions" src="https://img.shields.io/github/actions/workflow/status/naufaldi/ts-hooks-kit/ci.yml?branch=master" /></a>
+  <a href="https://github.com/naufaldi/ts-hooks-kit/blob/master/LICENSE"><img alt="license" src="https://img.shields.io/npm/l/@ts-hooks-kit/core" /></a>
+</p>
 
-[![npm version](https://img.shields.io/npm/v/@ts-hooks-kit/core)](https://www.npmjs.com/package/@ts-hooks-kit/core)
-[![license](https://img.shields.io/npm/l/@ts-hooks-kit/core)](https://github.com/naufaldi/ts-hooks-kit/blob/main/LICENSE)
-[![CI](https://github.com/naufaldi/ts-hooks-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/naufaldi/ts-hooks-kit/actions/workflows/ci.yml)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@ts-hooks-kit/core)](https://bundlephobia.com/package/@ts-hooks-kit/core)
+<p align="center">
+  Production-ready React hooks for React 18 &amp; 19, fully typed and tree-shakeable.<br />
+  <a href="https://github.com/naufaldi/ts-hooks-kit"><strong>github.com/naufaldi/ts-hooks-kit</strong></a>
+</p>
 
-## Install
+---
 
-```bash
+React applications need reliable, well-typed hooks — but maintaining them across React versions is hard. ts-hooks-kit is a batteries-included hooks library that picks up where [usehooks-ts](https://github.com/juliencrn/usehooks-ts) left off, providing 50 production-ready hooks with full React 18 and 19 support, zero runtime dependencies, and a migration path from usehooks-ts.
+
+## ✨ Features
+
+- **React 18 & 19:** tested against both versions in CI
+- **Type-safe:** first-class TypeScript with full type inference
+- **Tree-shakeable:** import only what you use, keep bundles small
+- **Zero dependencies:** React peer dependency only, no runtime deps
+- **Dual output:** ESM + CJS builds via tsdown
+- **Drop-in migration:** codemod to migrate from usehooks-ts automatically
+
+## 📦 Install
+
+```sh
 npm install @ts-hooks-kit/core
+
+# or
+
+yarn add @ts-hooks-kit/core
+
+# or
+
+pnpm add @ts-hooks-kit/core
 ```
 
-## Quick Start
+## ⚡️ Quick Start
 
 ```tsx
 import { useBoolean, useLocalStorage } from '@ts-hooks-kit/core'
@@ -30,36 +61,54 @@ export function Example() {
 }
 ```
 
-## Features
+## 🪝 Available Hooks
 
-- 50 exported hooks in `@ts-hooks-kit/core`
-- React `^18 || ^19` compatibility
-- TypeScript-first API surface
-- Zero runtime dependencies (React peer dependency only)
-- ESM + CJS output via tsdown
+**State**
+`useBoolean` · `useCounter` · `useDisclosure` · `useList` · `useMap` · `useQueue` · `useSet` · `useStateList` · `useStep` · `useToggle`
 
-## Migration from usehooks-ts
+**Storage**
+`useLocalStorage` · `useReadLocalStorage` · `useSessionStorage`
 
-- Migration guide: `docs/migration.md`
-- Codemod CLI: `node packages/codemod/bin/ts-hooks-kit-codemod.js <target-path> --dry`
-- Package import rewrite: `usehooks-ts` -> `@ts-hooks-kit/core`
+**Browser**
+`useCopyToClipboard` · `useDarkMode` · `useDocumentTitle` · `useGeolocation` · `useMediaQuery` · `useNetwork` · `usePermission` · `useScreen` · `useScript` · `useScrollLock` · `useTernaryDarkMode` · `useWindowSize`
 
-## Repository Layout
+**DOM**
+`useClickAnyWhere` · `useEventListener` · `useHover` · `useIntersectionObserver` · `useOnClickOutside` · `usePageLeave` · `useResizeObserver`
 
-- `packages/core/` - publishable hooks package (`@ts-hooks-kit/core`)
-- `packages/codemod/` - migration codemod tooling
-- `apps/docs/` - documentation site workspace
-- `docs/` - repository docs (migration, compatibility, notes)
-- `examples/sample-app/` - codemod migration validation sample
+**Timing**
+`useCountdown` · `useDebounceCallback` · `useDebounceValue` · `useIdle` · `useInterval` · `useThrottle` · `useTimeout`
 
-## Credits
+**Lifecycle**
+`useEventCallback` · `useIsClient` · `useIsMounted` · `useIsomorphicLayoutEffect` · `useMemoizedFn` · `usePrevious` · `useUnmount` · `useUpdate` · `useUpdateEffect`
 
-This project is a fork of [usehooks-ts](https://github.com/juliencrn/usehooks-ts) by [Julien CARON](https://github.com/juliencrn). We built on his excellent work to provide continued maintenance and React 19 compatibility. The original project baseline is usehooks-ts@3.1.1.
+**Data**
+`useAsync` · `usePagination`
 
-## Contributing
+## 📚 Documentation
 
-Contributions are welcome! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
+- [**Migration guide**](./docs/migration.md) to move from usehooks-ts to ts-hooks-kit
+- [**Compatibility**](./docs/compatibility.md) for React version support details
+- [**Contributing**](./CONTRIBUTING.md) to get involved in development
 
-## License
+## 🔄 Migration from usehooks-ts
 
-MIT -- see [LICENSE](./LICENSE) for details.
+Swap your imports automatically with the included codemod:
+
+```sh
+npx ts-hooks-kit-codemod <target-path> --dry  # preview changes
+npx ts-hooks-kit-codemod <target-path>         # apply changes
+```
+
+The codemod rewrites `usehooks-ts` imports to `@ts-hooks-kit/core` and handles any renamed hooks.
+
+## 👥 Contributors
+
+[![ts-hooks-kit contributors](https://contrib.rocks/image?repo=naufaldi/ts-hooks-kit)](https://github.com/naufaldi/ts-hooks-kit/graphs/contributors)
+
+## 🙏 Credits
+
+Built on the excellent work of [usehooks-ts](https://github.com/juliencrn/usehooks-ts) by [Julien Caron](https://github.com/juliencrn). Forked from v3.1.1 with continued maintenance and React 19 support.
+
+## 📜 License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary
- Redesigned README to match dinero.js's polished layout style
- Added centered badges, emoji section headers, and a tagline
- Organized all 50 hooks into categorized groups (State, Storage, Browser, DOM, Timing, Lifecycle, Data)
- Added migration codemod section and contributors image

## Test plan
- [ ] Verify markdown renders correctly on GitHub PR preview
- [ ] Check all badge URLs resolve (npm, bundlephobia, CI, license)
- [ ] Confirm hook count matches exports (50)

🤖 Generated with [Claude Code](https://claude.com/claude-code)