### PR TITLE
feat: npm publish workflow + docs + Netlify

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  NODE_VERSION: 20.19.0
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test
+
+      - name: Publish to npm
+        run: pnpm --filter @ts-hooks-kit/core publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 coverage
 generated
 apps/docs/build
+.netlify

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   Production-ready React hooks for React 18 &amp; 19, fully typed and tree-shakeable.<br />
-  <a href="https://github.com/naufaldi/ts-hooks-kit"><strong>github.com/naufaldi/ts-hooks-kit</strong></a>
+  <a href="https://ts-hooks-kit.netlify.app"><strong>Documentation</strong></a> · <a href="https://github.com/naufaldi/ts-hooks-kit"><strong>GitHub</strong></a>
 </p>
 
 ---
@@ -86,6 +86,7 @@ export function Example() {
 
 ## 📚 Documentation
 
+- [**Full documentation**](https://ts-hooks-kit.netlify.app) — live docs site with API reference
 - [**Migration guide**](./docs/migration.md) to move from usehooks-ts to ts-hooks-kit
 - [**Compatibility**](./docs/compatibility.md) for React version support details
 - [**Contributing**](./CONTRIBUTING.md) to get involved in development

--- a/apps/docs/app/content/getting-started.md
+++ b/apps/docs/app/content/getting-started.md
@@ -1,9 +1,21 @@
 # Getting Started
 
+## Requirements
+
+- React 18 or 19
+- TypeScript 5+ (recommended, not required)
+- Node.js 20+
+
 ## Install
 
 ```bash
 npm install @ts-hooks-kit/core
+
+# or
+yarn add @ts-hooks-kit/core
+
+# or
+pnpm add @ts-hooks-kit/core
 ```
 
 ## Basic usage
@@ -23,8 +35,11 @@ export function Example() {
 }
 ```
 
+Only the hooks you import are included in your bundle — every hook is independently tree-shakeable.
+
 ## Compatibility
 
 - React `^18 || ^19`
 - TypeScript-first APIs
 - ESM + CJS outputs
+- Tree-shakeable — import only what you need


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated npm publishing on `v*` tag push (uses `NPM_TOKEN` secret)
- Expand getting-started docs with requirements, yarn/pnpm install options, and tree-shaking note
- Update README with live docs site link (`ts-hooks-kit.netlify.app`)
- Add `.netlify` to `.gitignore` for Netlify CLI setup

## Test plan
- [x] `pnpm build` passes (all packages including docs)
- [x] `pnpm test` passes (295 tests, 51 files)
- [ ] After merge: add `NPM_TOKEN` secret to repo settings, then `git tag v0.1.0 && git push origin v0.1.0` to trigger first publish
- [ ] Run `netlify init` in repo root to connect docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)