### PR TITLE
fix(docs): improve accessibility (WCAG) and dev experience

### DIFF
--- a/apps/docs/app/components/docs/sidebar-nav.tsx
+++ b/apps/docs/app/components/docs/sidebar-nav.tsx
@@ -30,7 +30,11 @@ export function SidebarNav({ sections }: Props) {
                   }`
                 }
               >
-                {item.label}
+                {({ isActive }) => (
+                  <span aria-current={isActive ? 'page' : undefined}>
+                    {item.label}
+                  </span>
+                )}
               </NavLink>
             ))}
           </div>

--- a/apps/docs/app/components/markdown.tsx
+++ b/apps/docs/app/components/markdown.tsx
@@ -96,8 +96,11 @@ export function Markdown({ source }: { source: string }) {
               <table className="w-full text-sm" {...props}>{children}</table>
             </div>
           ),
+          thead: ({ children, ...props }) => (
+            <thead className="bg-muted" {...props}>{children}</thead>
+          ),
           th: ({ children, ...props }) => (
-            <th className="border border-border bg-muted px-3 py-2 text-left font-semibold" {...props}>
+            <th className="border border-border px-3 py-2 text-left font-semibold" scope="col" {...props}>
               {children}
             </th>
           ),

--- a/apps/docs/app/layouts/docs-layout.tsx
+++ b/apps/docs/app/layouts/docs-layout.tsx
@@ -39,7 +39,7 @@ export default function DocsLayout() {
           </div>
         </div>
       </header>
-      <div className="mx-auto grid max-w-[1220px] gap-6 px-5 md:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)_200px]">
+      <div id="main-content" className="mx-auto grid max-w-[1220px] gap-6 px-5 md:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)_200px]">
         <SidebarNav sections={sidebarSections} />
         <div className="min-w-0 py-8">
           <Outlet />

--- a/apps/docs/app/root.tsx
+++ b/apps/docs/app/root.tsx
@@ -24,6 +24,12 @@ export function Layout({ children }: { children: ReactNode }) {
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-accent focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+        >
+          Skip to main content
+        </a>
         {children}
         <ScrollRestoration />
         <Scripts />

--- a/apps/docs/app/styles.css
+++ b/apps/docs/app/styles.css
@@ -56,6 +56,12 @@ html {
   scroll-behavior: smooth;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 * {
   border-color: var(--color-border);
 }

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -2,7 +2,16 @@ import tailwindcss from '@tailwindcss/vite'
 import netlifyReactRouter from '@netlify/vite-plugin-react-router'
 import { reactRouter } from '@react-router/dev/vite'
 import { defineConfig } from 'vite'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   plugins: [tailwindcss(), reactRouter(), netlifyReactRouter()],
+  resolve: {
+    alias: {
+      '@ts-hooks-kit/core': resolve(__dirname, '../../packages/core/src'),
+    },
+  },
 })


### PR DESCRIPTION
## Summary

This PR addresses accessibility improvements for the documentation site:

### Changes
- **Skip link**: Added "Skip to main content" link for keyboard/screen reader users
- **aria-current**: Added `aria-current='page'` on active navigation links
- **Table semantics**: Added `scope='col'` to table headers for screen readers  
- **prefers-reduced-motion**: Added CSS media query to disable smooth scroll for users who prefer reduced motion
- **Dev experience**: Added Vite alias to import `@ts-hooks-kit/core` from source (no build step needed)

### Remaining Issues (for future issues)
The following items were identified in the audit but not addressed in this PR:
- Internal markdown links use `<a>` instead of `<Link>` component (SPA routing)
- Table rows need `scope='row'` (complex to implement with ReactMarkdown)
- Some color contrast ratios need verification (muted-foreground in dark mode)

### Testing
```bash
pnpm generate:docs
pnpm dev:docs
```

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>