### PR TITLE
fix(core): upstream parity for debounce, scroll lock, resize observer

### DIFF
--- a/packages/core/src/useDebounceCallback/useDebounceCallback.test.ts
+++ b/packages/core/src/useDebounceCallback/useDebounceCallback.test.ts
@@ -8,9 +8,7 @@ describe('useDebounceCallback()', () => {
   it('should debounce the callback', () => {
     const delay = 500
     const debouncedCallback = vitest.fn()
-    const { result } = renderHook(() =>
-      useDebounceCallback(debouncedCallback, delay),
-    )
+    const { result } = renderHook(() => useDebounceCallback(debouncedCallback, delay))
 
     act(() => {
       result.current('argument')
@@ -69,9 +67,7 @@ describe('useDebounceCallback()', () => {
   it('should cancel the debounced callback', () => {
     const delay = 500
     const debouncedCallback = vitest.fn()
-    const { result } = renderHook(() =>
-      useDebounceCallback(debouncedCallback, delay),
-    )
+    const { result } = renderHook(() => useDebounceCallback(debouncedCallback, delay))
 
     act(() => {
       result.current('argument')
@@ -88,9 +84,7 @@ describe('useDebounceCallback()', () => {
   it('should flush the debounced callback', () => {
     const delay = 500
     const debouncedCallback = vitest.fn()
-    const { result } = renderHook(() =>
-      useDebounceCallback(debouncedCallback, delay),
-    )
+    const { result } = renderHook(() => useDebounceCallback(debouncedCallback, delay))
 
     act(() => {
       result.current('argument')
@@ -106,5 +100,36 @@ describe('useDebounceCallback()', () => {
 
     // The callback should be invoked immediately after flushing
     expect(debouncedCallback).toHaveBeenCalled()
+  })
+
+  it('should debounce when options object is a new literal each render', () => {
+    const debouncedCallback = vitest.fn()
+    const { result, rerender } = renderHook(() =>
+      useDebounceCallback(debouncedCallback, 100, { leading: false, trailing: true }),
+    )
+
+    act(() => {
+      result.current('a')
+    })
+    rerender()
+    act(() => {
+      result.current('b')
+    })
+
+    expect(debouncedCallback).not.toHaveBeenCalled()
+    vitest.advanceTimersByTime(100)
+    expect(debouncedCallback).toHaveBeenCalledTimes(1)
+    expect(debouncedCallback).toHaveBeenCalledWith('b')
+  })
+
+  it('should report isPending false after cancel', () => {
+    const { result } = renderHook(() => useDebounceCallback(vitest.fn(), 100))
+
+    act(() => {
+      result.current('x')
+      expect(result.current.isPending()).toBe(true)
+      result.current.cancel()
+      expect(result.current.isPending()).toBe(false)
+    })
   })
 })

--- a/packages/core/src/useDebounceCallback/useDebounceCallback.ts
+++ b/packages/core/src/useDebounceCallback/useDebounceCallback.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useMemo, useRef } from 'react'
 
 import { useUnmount } from '../useUnmount'
 import { debounce } from '../utils'
@@ -58,40 +58,43 @@ export function useDebounceCallback<T extends (...args: any) => ReturnType<T>>(
   delay = 500,
   options?: DebounceOptions,
 ): DebouncedState<T> {
-  const debouncedFunc = useRef<DebouncedFunction<T> | null>(null)
+  const funcRef = useRef(func)
+  funcRef.current = func
 
-  useUnmount(() => {
-    if (debouncedFunc.current) {
-      debouncedFunc.current.cancel()
-    }
-  })
+  const leading = options?.leading ?? false
+  const trailing = options?.trailing !== false
+  const maxWait = options?.maxWait
+
+  const activeDebounced = useRef<DebouncedFunction<T> | null>(null)
 
   const debounced = useMemo(() => {
-    const debouncedFuncInstance = debounce(func, delay, options)
+    activeDebounced.current?.cancel()
 
-    const wrappedFunc: DebouncedState<T> = (...args: Parameters<T>) => {
-      return debouncedFuncInstance(...args)
-    }
+    const d = debounce((...args: Parameters<T>) => funcRef.current(...args), delay, {
+      leading,
+      trailing,
+      maxWait,
+    })
+    activeDebounced.current = d
+
+    const wrappedFunc: DebouncedState<T> = (...args: Parameters<T>) => d(...args)
 
     wrappedFunc.cancel = () => {
-      debouncedFuncInstance.cancel()
+      d.cancel()
     }
 
-    wrappedFunc.isPending = () => {
-      return !!debouncedFunc.current
-    }
+    wrappedFunc.isPending = () => d.isPending()
 
     wrappedFunc.flush = () => {
-      return debouncedFuncInstance.flush()
+      return d.flush()
     }
 
     return wrappedFunc
-  }, [func, delay, options])
+  }, [delay, leading, trailing, maxWait])
 
-  // Update the debounced function ref whenever func, wait, or options change
-  useEffect(() => {
-    debouncedFunc.current = debounce(func, delay, options)
-  }, [func, delay, options])
+  useUnmount(() => {
+    activeDebounced.current?.cancel()
+  })
 
   return debounced
 }

--- a/packages/core/src/useLocalStorage/useLocalStorage.test.ts
+++ b/packages/core/src/useLocalStorage/useLocalStorage.test.ts
@@ -21,6 +21,13 @@ describe('useLocalStorage()', () => {
     expect(result.current[0]).toBe('value')
   })
 
+  it('setValue reference is stable across re-renders', () => {
+    const { result, rerender } = renderHook(() => useLocalStorage('stable-set', 0))
+    const setA = result.current[1]
+    rerender()
+    expect(result.current[1]).toBe(setA)
+  })
+
   it('Initial state is a callback function', () => {
     const { result } = renderHook(() => useLocalStorage('key', () => 'value'))
 

--- a/packages/core/src/useResizeObserver/useResizeObserver.test.tsx
+++ b/packages/core/src/useResizeObserver/useResizeObserver.test.tsx
@@ -1,4 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
+import type { RefObject } from 'react'
+
 
 import { useResizeObserver } from './useResizeObserver'
 
@@ -42,9 +44,7 @@ describe('useResizeObserver()', () => {
 
   it('should return initial undefined sizes', () => {
     const ref = { current: document.createElement('div') }
-    const { result } = renderHook(() =>
-      useResizeObserver({ ref }),
-    )
+    const { result } = renderHook(() => useResizeObserver({ ref }))
 
     expect(result.current.width).toBeUndefined()
     expect(result.current.height).toBeUndefined()
@@ -52,9 +52,7 @@ describe('useResizeObserver()', () => {
 
   it('should return the observed element sizes', () => {
     const ref = { current: document.createElement('div') }
-    const { result } = renderHook(() =>
-      useResizeObserver({ ref }),
-    )
+    const { result } = renderHook(() => useResizeObserver({ ref }))
 
     triggerResize(100, 100)
 
@@ -64,9 +62,7 @@ describe('useResizeObserver()', () => {
 
   it('should update size when element is resized', () => {
     const ref = { current: document.createElement('div') }
-    const { result } = renderHook(() =>
-      useResizeObserver({ ref }),
-    )
+    const { result } = renderHook(() => useResizeObserver({ ref }))
 
     triggerResize(100, 100)
     expect(result.current.width).toBe(100)
@@ -79,12 +75,25 @@ describe('useResizeObserver()', () => {
   it('should use onResize callback', () => {
     const ref = { current: document.createElement('div') }
     const onResize = vi.fn()
-    renderHook(() =>
-      useResizeObserver({ ref, onResize }),
-    )
+    renderHook(() => useResizeObserver({ ref, onResize }))
 
     triggerResize(200, 200)
 
     expect(onResize).toHaveBeenCalledWith({ width: 200, height: 200 })
+  })
+
+  it('should observe after ref.current is set on a later render', () => {
+    const ref: RefObject<HTMLDivElement | null> = { current: null }
+    const { result, rerender } = renderHook(() => useResizeObserver({ ref }))
+
+    expect(result.current.width).toBeUndefined()
+
+    ref.current = document.createElement('div')
+    rerender()
+
+    triggerResize(42, 42)
+
+    expect(result.current.width).toBe(42)
+    expect(result.current.height).toBe(42)
   })
 })

--- a/packages/core/src/useResizeObserver/useResizeObserver.ts
+++ b/packages/core/src/useResizeObserver/useResizeObserver.ts
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import type { RefObject } from 'react'
 
 import { useIsMounted } from '../useIsMounted'
+import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 
 /** The size of the observed element. */
 export type Size = {
@@ -60,48 +61,90 @@ export function useResizeObserver<T extends HTMLElement = HTMLElement>(
   const onResize = useRef<((size: Size) => void) | undefined>(undefined)
   onResize.current = options.onResize
 
-  useEffect(() => {
-    if (!ref.current) return
+  const observedElement = ref.current
 
-    if (typeof window === 'undefined' || !('ResizeObserver' in window)) return
+  useIsomorphicLayoutEffect(() => {
+    if (typeof window === 'undefined' || !('ResizeObserver' in window)) {
+      return
+    }
 
-    const observer = new ResizeObserver(([entry]) => {
-      if (!entry) return
+    let cancelled = false
+    let observer: ResizeObserver | null = null
+    let rafId = 0
+    let pollAttempts = 0
 
-      const boxProp =
-        box === 'border-box'
-          ? 'borderBoxSize'
-          : box === 'device-pixel-content-box'
-            ? 'devicePixelContentBoxSize'
-            : 'contentBoxSize'
+    const teardown = () => {
+      observer?.disconnect()
+      observer = null
+    }
 
-      const newWidth = extractSize(entry, boxProp, 'inlineSize')
-      const newHeight = extractSize(entry, boxProp, 'blockSize')
+    const bind = (element: T) => {
+      teardown()
 
-      const hasChanged =
-        previousSize.current.width !== newWidth || previousSize.current.height !== newHeight
+      observer = new ResizeObserver(([entry]) => {
+        if (!entry) return
 
-      if (hasChanged) {
-        const newSize: Size = { width: newWidth, height: newHeight }
-        previousSize.current.width = newWidth
-        previousSize.current.height = newHeight
+        const boxProp =
+          box === 'border-box'
+            ? 'borderBoxSize'
+            : box === 'device-pixel-content-box'
+              ? 'devicePixelContentBoxSize'
+              : 'contentBoxSize'
 
-        if (onResize.current) {
-          onResize.current(newSize)
-        } else {
-          if (isMounted()) {
+        const newWidth = extractSize(entry, boxProp, 'inlineSize')
+        const newHeight = extractSize(entry, boxProp, 'blockSize')
+
+        const hasChanged =
+          previousSize.current.width !== newWidth || previousSize.current.height !== newHeight
+
+        if (hasChanged) {
+          const newSize: Size = { width: newWidth, height: newHeight }
+          previousSize.current.width = newWidth
+          previousSize.current.height = newHeight
+
+          if (onResize.current) {
+            onResize.current(newSize)
+          } else if (isMounted()) {
             setSize(newSize)
           }
         }
-      }
-    })
+      })
 
-    observer.observe(ref.current, { box })
+      observer.observe(element, { box })
+    }
+
+    const run = () => {
+      if (cancelled) {
+        return
+      }
+
+      const element = ref.current
+
+      if (!element) {
+        teardown()
+        previousSize.current = { ...initialSize }
+        if (!onResize.current) {
+          setSize(initialSize)
+        }
+
+        if (pollAttempts++ < 32) {
+          rafId = requestAnimationFrame(run)
+        }
+        return
+      }
+
+      pollAttempts = 0
+      bind(element)
+    }
+
+    run()
 
     return () => {
-      observer.disconnect()
+      cancelled = true
+      cancelAnimationFrame(rafId)
+      teardown()
     }
-  }, [box, ref, isMounted])
+  }, [box, observedElement, isMounted, ref])
 
   return { width, height }
 }

--- a/packages/core/src/useScrollLock/useScrollLock.test.tsx
+++ b/packages/core/src/useScrollLock/useScrollLock.test.tsx
@@ -1,10 +1,16 @@
 import { act, renderHook } from '@testing-library/react'
+import { createElement, StrictMode, type ReactNode } from 'react'
+
 
 import { useScrollLock } from './useScrollLock'
+
+const strictWrapper = ({ children }: { children: ReactNode }) =>
+  createElement(StrictMode, null, children)
 
 describe('useScrollLock()', () => {
   beforeEach(() => {
     document.body.style.removeProperty('overflow')
+    document.body.style.removeProperty('padding-right')
   })
 
   it('should initially lock and unlock body', () => {
@@ -33,9 +39,7 @@ describe('useScrollLock()', () => {
     target.id = 'target'
     document.body.appendChild(target)
 
-    const { unmount } = renderHook(() =>
-      useScrollLock({ lockTarget: '#target' }),
-    )
+    const { unmount } = renderHook(() => useScrollLock({ lockTarget: '#target' }))
 
     expect(target.style.overflow).toBe('hidden')
     unmount()
@@ -80,9 +84,7 @@ describe('useScrollLock()', () => {
   })
 
   it('should unlock on unmount even with initial is locked', () => {
-    const { unmount, result } = renderHook(() =>
-      useScrollLock({ autoLock: false }),
-    )
+    const { unmount, result } = renderHook(() => useScrollLock({ autoLock: false }))
 
     expect(document.body.style.overflow).toBe('')
     act(() => {
@@ -94,9 +96,7 @@ describe('useScrollLock()', () => {
   })
 
   it('should fallback to document.body if the target element is not found', () => {
-    const { unmount } = renderHook(() =>
-      useScrollLock({ lockTarget: '#non-existing' }),
-    )
+    const { unmount } = renderHook(() => useScrollLock({ lockTarget: '#non-existing' }))
 
     expect(document.body.style.overflow).toBe('hidden')
     unmount()
@@ -111,5 +111,29 @@ describe('useScrollLock()', () => {
     expect(document.body.style.paddingRight).toBe(`${scrollbarWidth}px`)
     unmount()
     expect(document.body.style.paddingRight).toBe('')
+  })
+
+  it('should restore body overflow after unmount in StrictMode', () => {
+    const { unmount } = renderHook(() => useScrollLock(), {
+      wrapper: strictWrapper,
+    })
+
+    expect(document.body.style.overflow).toBe('hidden')
+    unmount()
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('should restore body overflow with manual lock in StrictMode', () => {
+    const { unmount, result } = renderHook(() => useScrollLock({ autoLock: false }), {
+      wrapper: strictWrapper,
+    })
+
+    expect(document.body.style.overflow).toBe('')
+    act(() => {
+      result.current.lock()
+    })
+    expect(document.body.style.overflow).toBe('hidden')
+    unmount()
+    expect(document.body.style.overflow).toBe('')
   })
 })

--- a/packages/core/src/useScrollLock/useScrollLock.ts
+++ b/packages/core/src/useScrollLock/useScrollLock.ts
@@ -38,6 +38,9 @@ export type OriginalStyle = {
 
 const IS_SERVER = typeof window === 'undefined'
 
+const scrollLockDepthByElement = new WeakMap<HTMLElement, number>()
+const scrollLockOriginalStyles = new WeakMap<HTMLElement, OriginalStyle>()
+
 /**
  * A custom hook that locks and unlocks scroll.
  * @param {UseScrollLockOptions} [options] - Options to configure the hook, by default it will lock the scroll automatically.
@@ -66,42 +69,65 @@ export function useScrollLock(options: UseScrollLockOptions = {}): UseScrollLock
   const { autoLock = true, lockTarget, widthReflow = true } = options
   const [isLocked, setIsLocked] = useState(false)
   const target = useRef<HTMLElement | null>(null)
-  const originalStyle = useRef<OriginalStyle | null>(null)
 
   const lock = () => {
-    if (target.current) {
-      const { overflow, paddingRight } = target.current.style
+    const el = target.current
+    if (!el || IS_SERVER) {
+      return
+    }
 
-      // Save the original styles
-      originalStyle.current = { overflow, paddingRight }
+    const depth = scrollLockDepthByElement.get(el) ?? 0
+    scrollLockDepthByElement.set(el, depth + 1)
 
-      // Prevent width reflow
+    if (depth === 0) {
+      scrollLockOriginalStyles.set(el, {
+        overflow: el.style.overflow,
+        paddingRight: el.style.paddingRight,
+      })
+
       if (widthReflow) {
-        // Use window inner width if body is the target as global scrollbar isn't part of the document
-        const offsetWidth =
-          target.current === document.body ? window.innerWidth : target.current.offsetWidth
-        // Get current computed padding right in pixels
-        const currentPaddingRight =
-          parseInt(window.getComputedStyle(target.current).paddingRight, 10) || 0
+        const offsetWidth = el === document.body ? window.innerWidth : el.offsetWidth
+        const currentPaddingRight = parseInt(window.getComputedStyle(el).paddingRight, 10) || 0
 
-        const scrollbarWidth = offsetWidth - target.current.scrollWidth
-        target.current.style.paddingRight = `${scrollbarWidth + currentPaddingRight}px`
+        const scrollbarWidth = offsetWidth - el.scrollWidth
+        el.style.paddingRight = `${scrollbarWidth + currentPaddingRight}px`
       }
 
-      // Lock the scroll
-      target.current.style.overflow = 'hidden'
-
-      setIsLocked(true)
+      el.style.overflow = 'hidden'
     }
+
+    setIsLocked(true)
   }
 
   const unlock = () => {
-    if (target.current && originalStyle.current) {
-      target.current.style.overflow = originalStyle.current.overflow
+    const el = target.current
+    if (!el || IS_SERVER) {
+      setIsLocked(false)
+      return
+    }
 
-      // Only reset padding right if we changed it
+    const depth = scrollLockDepthByElement.get(el) ?? 0
+    if (depth <= 0) {
+      setIsLocked(false)
+      return
+    }
+
+    const next = depth - 1
+    scrollLockDepthByElement.set(el, next)
+
+    if (next > 0) {
+      setIsLocked(true)
+      return
+    }
+
+    scrollLockDepthByElement.delete(el)
+    const saved = scrollLockOriginalStyles.get(el)
+    scrollLockOriginalStyles.delete(el)
+
+    if (saved) {
+      el.style.overflow = saved.overflow
       if (widthReflow) {
-        target.current.style.paddingRight = originalStyle.current.paddingRight
+        el.style.paddingRight = saved.paddingRight
       }
     }
 

--- a/packages/core/src/utils/debounce.ts
+++ b/packages/core/src/utils/debounce.ts
@@ -15,6 +15,8 @@ export interface DebouncedFunction<T extends (...args: any[]) => any> {
   cancel: () => void
   /** Immediately invoke pending invocations. */
   flush: () => ReturnType<T> | undefined
+  /** Whether a trailing / maxWait invocation is still scheduled. */
+  isPending: () => boolean
 }
 
 /**
@@ -62,11 +64,7 @@ export function debounce<T extends (...args: any[]) => any>(
 
   const shouldInvoke = (time: number): boolean => {
     const timeSinceLastCall = time - (lastCallTime ?? 0)
-    return (
-      lastCallTime === null ||
-      timeSinceLastCall >= delay ||
-      timeSinceLastCall < 0
-    )
+    return lastCallTime === null || timeSinceLastCall >= delay || timeSinceLastCall < 0
   }
 
   const trailingEdge = (): ReturnType<T> | undefined => {
@@ -153,6 +151,10 @@ export function debounce<T extends (...args: any[]) => any>(
       }
     }
     return lastResult
+  }
+
+  debounced.isPending = (): boolean => {
+    return timeoutId !== null || maxTimeoutId !== null
   }
 
   return debounced as DebouncedFunction<T>


### PR DESCRIPTION
## Summary

Implements **Tier 1** upstream parity fixes from the mirrored tracking issues, aligned with reports on [juliencrn/usehooks-ts](https://github.com/juliencrn/usehooks-ts).

## Closes

- **#28** — `useDebounceCallback`: options keyed by primitives (`leading` / `trailing` / `maxWait`) so inline option literals do not reset debouncing; latest `func` via ref; single debounced instance; `isPending()` backed by timer state on `debounce()`.
- **#29** — `useScrollLock`: per-element lock depth (`WeakMap`) + saved styles so React Strict Mode and nested locks on the same element restore correctly.
- **#31** — `useResizeObserver`: `useIsomorphicLayoutEffect` keyed on `ref.current` snapshot, teardown/rebind on attach-detach, short `requestAnimationFrame` polling when ref is initially `null`.

## Related (partial)

- **#30** — `useLocalStorage`: adds regression test for **stable `setValue`**; JSON default serializer / full hydration story left for follow-up (see issue comments).

## Tests

- `useDebounceCallback.test.ts` — unstable options literal; `isPending` after `cancel`
- `useScrollLock.test.tsx` — StrictMode + autoLock / manual lock
- `useResizeObserver.test.tsx` — ref attached on a later render
- `useLocalStorage.test.ts` — stable `setValue` across rerenders

## Still open on the tracker (not in this PR)

| Issue | Topic | Why still open |
|-------|--------|----------------|
| #30 | LocalStorage hydration / render-phase / serializer docs | Only the stability test landed; SSR/hydration and API semantics need scoped repros + design. |
| #32 | `useOnClickOutside` null / multi-ref | API + types; no implementation in this PR. |
| #33 | Export `readValue` for `useReadLocalStorage` | Small public API addition. |
| #34 | `useEventListener` docs TypeScript | Docs / example fix. |
| #35 | `useUnmount` ref timing | Lifecycle compliance; may move work to layout effect. |
| #36 | `useHover` stuck when node removed | Pointer/target lifetime; needs event strategy. |
| #37 | `useMediaQuery` SSR | Document / default server value; tests. |
| #38 | `useDebounceValue` `isPending` UX | May need reactive pending state separate from callback hook. |
| #39 | React 18/19 umbrella | CI matrix / types audit. |

See each issue’s **verification comment** for suggested next steps.
